### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,7 @@ class ES3Plugin {
       spawnSync("npx", ["tsc", "-p", tsConfigPath], {
         shell: true,
       });
+      fse.ensureDirSync(es3Dist);
       fse.copySync(es3Dist, outputPath);
       fse.removeSync(es3Dist);
       // delete unneeded fields


### PR DESCRIPTION
Fix the error ENOENT: no such file or directory, stat '.....\node_modules\webpack-es3-plugin\temp' under Windows 10 by ensuring that the temp folder exists